### PR TITLE
Add unsign to ZipSigner

### DIFF
--- a/lib/src/test/kotlin/org/jetbrains/zip/signer/signing/SingningTest.kt
+++ b/lib/src/test/kotlin/org/jetbrains/zip/signer/signing/SingningTest.kt
@@ -9,6 +9,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.rules.TestName
+import java.io.File
+import java.util.*
 
 
 class SigningTest : BaseTest() {
@@ -113,6 +115,25 @@ class SigningTest : BaseTest() {
             ZipUtils.modifyZipFile(this)
             verifyZip(testFileContent)
             Assert.assertFalse(isSignedBy(signs))
+        }
+    }
+
+    @Test
+    fun `unsigned file is identical to original zip`() {
+        val uuid = UUID.randomUUID().toString()
+        val zip = createZip(testName.methodName, uuid);
+        val signedZip = sign(zip, listOf(getCertificate()))
+
+        val unsignedFile = File(signedZip.parentFile, "$uuid-unsigned.zip")
+        ZipSigner.unsign(signedZip, unsignedFile)
+
+        zip.inputStream().use { orig ->
+            unsignedFile.inputStream().use { unsigned ->
+                do {
+                    val origByte = orig.read()
+                    Assert.assertEquals("Original and unsigned zip file differs", origByte, unsigned.read())
+                } while (origByte != -1)
+            }
         }
     }
 }


### PR DESCRIPTION
For custom repositories I am signing plugins with an internal CA which issues certs with a max age of a year. My plan is to have a simple resigning/cert rotation tool which will pull down plugins from the repository, validate the signature against the "old" public key, unsign and sign using a new chain + private key followed by reuploading them to the repo.

I noticed after testing (when I tried to just validate + sign) that there is logic to check for existing signatures and append instead of replace (makes sense for the JB marketplace use case). So here I am creating a unsign method so I can call it :D

Let me know what you think.