### PR TITLE
Fix cli artifacts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,9 @@ publishing {
             artifactId = "marketplace-zip-signer"
             version = project.version.toString()
             from(project(":lib").components["java"])
+            artifact(project(":cli").tasks.shadowJar) {
+                classifier = "cli"
+            }
             configurePom()
         }
         create<MavenPublication>("zip-signer-maven-all") {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -17,6 +17,7 @@ tasks {
         }
     }
     shadowJar {
+        archiveClassifier.set("")
         archiveFileName.set("marketplace-zip-signer-cli.jar")
     }
 }


### PR DESCRIPTION
I removed `-all` classifier for `org.jetbrains:marketplace-zip-signer-cli`. It should fix the mess with resolving artifacts. I also added `:cli` artifacts to `org.jetbrains:marketplace-zip-signer` with `-cli` classifier, as @hsz asked. 

We are going to deprecate `org.jetbrains:marketplace-zip-signer-all` and `org.jetbrains:marketplace-zip-signer-cli` later somehow since all artifacts will be accessible through `org.jetbrains:marketplace-zip-signer` via `-all` and `-cli` classifiers.