### PR TITLE
Fix NPE in getCrlUris

### DIFF
--- a/lib/src/main/kotlin/org/jetbrains/zip/signer/signer/CertificateUtils.kt
+++ b/lib/src/main/kotlin/org/jetbrains/zip/signer/signer/CertificateUtils.kt
@@ -120,6 +120,7 @@ object CertificateUtils {
     @JvmStatic
     fun getCrlUris(certificate: X509Certificate): List<URI> {
         val crlDistributionPointsBytes = certificate.getExtensionValue(Extension.cRLDistributionPoints.id)
+            ?: return emptyList()
         val derOctetString = ASN1InputStream(ByteArrayInputStream(crlDistributionPointsBytes)).use {
             it.readObject() as DEROctetString
         }

--- a/lib/src/test/kotlin/org/jetbrains/zip/signer/signer/CertificateUtilsTest.kt
+++ b/lib/src/test/kotlin/org/jetbrains/zip/signer/signer/CertificateUtilsTest.kt
@@ -1,0 +1,22 @@
+package org.jetbrains.zip.signer.signer
+
+import junit.framework.TestCase.assertEquals
+import org.jetbrains.zip.signer.BaseTest
+import org.junit.Test
+import java.security.cert.X509CRL
+
+class CertificateUtilsTest : BaseTest() {
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `throw an exception if no revocation lists are found`() {
+        CertificateUtils.getRevocationLists(getChain().certificates)
+    }
+    
+    @Test
+    fun `return an empty list if only the CA cert is provided`() {
+        assertEquals(
+            emptyList<X509CRL>(),
+            CertificateUtils.getRevocationLists(getCACertificate().certificates)
+        )
+    }
+}


### PR DESCRIPTION
We end up with the following exception without the null check:
```
Caused by: java.lang.NullPointerException
	at java.io.ByteArrayInputStream.<init>(ByteArrayInputStream.java:106)
	at org.jetbrains.zip.signer.signer.CertificateUtils.getCrlUris(CertificateUtils.kt:123)
	at org.jetbrains.zip.signer.signer.CertificateUtils.getRevocationLists(CertificateUtils.kt:106)
	at org.jetbrains.zip.signer.signer.CertificateUtilsTest.throw an exception if no revocation lists are found(CertificateUtilsTest.kt:12)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:19)
	... 35 more
```