### PR TITLE
Relax the byte channel interface requirement in FileChannelDataSource…

### DIFF
--- a/lib/src/main/kotlin/org/jetbrains/zip/signer/datasource/FileChannelDataSource.kt
+++ b/lib/src/main/kotlin/org/jetbrains/zip/signer/datasource/FileChannelDataSource.kt
@@ -1,93 +1,10 @@
 package org.jetbrains.zip.signer.datasource
 
-import java.io.IOException
-import java.nio.BufferOverflowException
-import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
-import java.nio.channels.WritableByteChannel
 
+@Deprecated("Use SeekableByteChannelDataSource instead")
 class FileChannelDataSource(
     private val channel: FileChannel,
     private val offset: Long = 0,
     val size: Long? = null
-) : DataSource {
-    companion object {
-        private const val MAX_READ_CHUNK_SIZE = 1024 * 1024
-        private fun checkChunkValid(offset: Long, size: Long, sourceSize: Long) {
-            val endOffset = offset + size
-            if (offset < 0) throw IndexOutOfBoundsException("offset: $offset")
-            if (size < 0) throw IndexOutOfBoundsException("size: $size")
-            if (offset > sourceSize) throw IndexOutOfBoundsException("offset ($offset) > source size ($sourceSize)")
-            if (endOffset < offset) throw IndexOutOfBoundsException("offset ($offset) + size ($size) overflow")
-            if (endOffset > sourceSize) throw IndexOutOfBoundsException("offset ($offset) + size ($size) > source size ($sourceSize)")
-        }
-    }
-
-    init {
-        if (offset < 0) throw IndexOutOfBoundsException("offset: $size")
-        if (size != null && size < 0) throw IndexOutOfBoundsException("size: $size")
-    }
-
-    override fun size() = size ?: channel.size()
-
-    override fun slice(offset: Long, size: Long): FileChannelDataSource {
-        val sourceSize = size()
-        checkChunkValid(offset, size, sourceSize)
-        return if (offset == 0L && size == sourceSize) this
-        else FileChannelDataSource(channel, this.offset + offset, size)
-    }
-
-    override fun feed(writableByteChannel: WritableByteChannel, offset: Long, size: Long) {
-        val sourceSize = size()
-        checkChunkValid(offset, size, sourceSize)
-        if (size == 0L) return
-        var chunkOffsetInFile = this.offset + offset
-        var remaining = size
-        val buf = ByteBuffer.allocateDirect(remaining.toInt().coerceAtMost(MAX_READ_CHUNK_SIZE))
-        while (remaining > 0) {
-            val chunkSize = remaining.coerceAtMost(buf.capacity().toLong()).toInt()
-            var chunkRemaining = chunkSize
-            buf.limit(chunkSize)
-            channel.position(chunkOffsetInFile)
-            while (chunkRemaining > 0) {
-                val read = channel.read(buf)
-                if (read < 0) throw IOException("Unexpected EOF encountered")
-                chunkRemaining -= read
-            }
-            buf.flip()
-            writableByteChannel.write(buf)
-            buf.clear()
-            chunkOffsetInFile += chunkSize.toLong()
-            remaining -= chunkSize.toLong()
-        }
-    }
-
-    override fun copyTo(offset: Long, size: Int, dest: ByteBuffer) {
-        val sourceSize = size()
-        checkChunkValid(offset, size.toLong(), sourceSize)
-        if (size == 0) return
-        if (size > dest.remaining()) throw BufferOverflowException()
-        var offsetInFile = this.offset + offset
-        var remaining = size
-        val prevLimit = dest.limit()
-        try {
-            dest.limit(dest.position() + size)
-            while (remaining > 0) {
-                channel.position(offsetInFile)
-                val chunkSize: Int = channel.read(dest)
-                offsetInFile += chunkSize.toLong()
-                remaining -= chunkSize
-            }
-        } finally {
-            dest.limit(prevLimit)
-        }
-    }
-
-    override fun getByteBuffer(offset: Long, size: Int): ByteBuffer {
-        if (size < 0) throw IndexOutOfBoundsException("size: $size")
-        val result = ByteBuffer.allocate(size)
-        copyTo(offset, size, result)
-        result.flip()
-        return result
-    }
-}
+) : DataSource by SeekableByteChannelDataSource(channel, offset, size)

--- a/lib/src/main/kotlin/org/jetbrains/zip/signer/datasource/SeekableByteChannelDataSource.kt
+++ b/lib/src/main/kotlin/org/jetbrains/zip/signer/datasource/SeekableByteChannelDataSource.kt
@@ -1,0 +1,94 @@
+package org.jetbrains.zip.signer.datasource
+
+import java.io.IOException
+import java.nio.BufferOverflowException
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.channels.SeekableByteChannel
+import java.nio.channels.WritableByteChannel
+
+class SeekableByteChannelDataSource(
+    private val channel: SeekableByteChannel,
+    private val offset: Long = 0,
+    val size: Long? = null
+) : DataSource {
+    companion object {
+        private const val MAX_READ_CHUNK_SIZE = 1024 * 1024
+        private fun checkChunkValid(offset: Long, size: Long, sourceSize: Long) {
+            val endOffset = offset + size
+            if (offset < 0) throw IndexOutOfBoundsException("offset: $offset")
+            if (size < 0) throw IndexOutOfBoundsException("size: $size")
+            if (offset > sourceSize) throw IndexOutOfBoundsException("offset ($offset) > source size ($sourceSize)")
+            if (endOffset < offset) throw IndexOutOfBoundsException("offset ($offset) + size ($size) overflow")
+            if (endOffset > sourceSize) throw IndexOutOfBoundsException("offset ($offset) + size ($size) > source size ($sourceSize)")
+        }
+    }
+
+    init {
+        if (offset < 0) throw IndexOutOfBoundsException("offset: $size")
+        if (size != null && size < 0) throw IndexOutOfBoundsException("size: $size")
+    }
+
+    override fun size() = size ?: channel.size()
+
+    override fun slice(offset: Long, size: Long): SeekableByteChannelDataSource {
+        val sourceSize = size()
+        checkChunkValid(offset, size, sourceSize)
+        return if (offset == 0L && size == sourceSize) this
+        else SeekableByteChannelDataSource(channel, this.offset + offset, size)
+    }
+
+    override fun feed(writableByteChannel: WritableByteChannel, offset: Long, size: Long) {
+        val sourceSize = size()
+        checkChunkValid(offset, size, sourceSize)
+        if (size == 0L) return
+        var chunkOffsetInFile = this.offset + offset
+        var remaining = size
+        val buf = ByteBuffer.allocateDirect(remaining.toInt().coerceAtMost(MAX_READ_CHUNK_SIZE))
+        while (remaining > 0) {
+            val chunkSize = remaining.coerceAtMost(buf.capacity().toLong()).toInt()
+            var chunkRemaining = chunkSize
+            buf.limit(chunkSize)
+            channel.position(chunkOffsetInFile)
+            while (chunkRemaining > 0) {
+                val read = channel.read(buf)
+                if (read < 0) throw IOException("Unexpected EOF encountered")
+                chunkRemaining -= read
+            }
+            buf.flip()
+            writableByteChannel.write(buf)
+            buf.clear()
+            chunkOffsetInFile += chunkSize.toLong()
+            remaining -= chunkSize.toLong()
+        }
+    }
+
+    override fun copyTo(offset: Long, size: Int, dest: ByteBuffer) {
+        val sourceSize = size()
+        checkChunkValid(offset, size.toLong(), sourceSize)
+        if (size == 0) return
+        if (size > dest.remaining()) throw BufferOverflowException()
+        var offsetInFile = this.offset + offset
+        var remaining = size
+        val prevLimit = dest.limit()
+        try {
+            dest.limit(dest.position() + size)
+            while (remaining > 0) {
+                channel.position(offsetInFile)
+                val chunkSize: Int = channel.read(dest)
+                offsetInFile += chunkSize.toLong()
+                remaining -= chunkSize
+            }
+        } finally {
+            dest.limit(prevLimit)
+        }
+    }
+
+    override fun getByteBuffer(offset: Long, size: Int): ByteBuffer {
+        if (size < 0) throw IndexOutOfBoundsException("size: $size")
+        val result = ByteBuffer.allocate(size)
+        copyTo(offset, size, result)
+        result.flip()
+        return result
+    }
+}

--- a/lib/src/main/kotlin/org/jetbrains/zip/signer/signing/ZipSigner.kt
+++ b/lib/src/main/kotlin/org/jetbrains/zip/signer/signing/ZipSigner.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.zip.signer.signing
 
 import org.jetbrains.zip.signer.datasource.DataSource
-import org.jetbrains.zip.signer.datasource.FileChannelDataSource
+import org.jetbrains.zip.signer.datasource.SeekableByteChannelDataSource
 import org.jetbrains.zip.signer.digest.DigestUtils
 import org.jetbrains.zip.signer.metadata.ContentDigestAlgorithm
 import org.jetbrains.zip.signer.metadata.ZipMetadata
@@ -29,7 +29,7 @@ object ZipSigner {
             RandomAccessFile(outputFile, "rw").use { outputRandomAccessFile ->
                 outputRandomAccessFile.setLength(0)
                 sign(
-                    FileChannelDataSource(inputRandomAccessFile.channel),
+                    SeekableByteChannelDataSource(inputRandomAccessFile.channel),
                     outputRandomAccessFile.channel,
                     certificates,
                     signatureProvider
@@ -46,7 +46,7 @@ object ZipSigner {
         RandomAccessFile(inputFile, "r").use { inputRandomAccessFile ->
             RandomAccessFile(outputFile, "rw").use { outputRandomAccessFile ->
                 outputRandomAccessFile.setLength(0)
-                val inputDataSource = FileChannelDataSource(inputRandomAccessFile.channel)
+                val inputDataSource = SeekableByteChannelDataSource(inputRandomAccessFile.channel)
                 val inputZipSectionsInformation = ZipUtils.findZipSectionsInformation(inputDataSource)
                 val inputSigningBlock = ZipMetadata.findInZip(inputDataSource, inputZipSectionsInformation)
                 val inputZipSections =

--- a/lib/src/main/kotlin/org/jetbrains/zip/signer/verifier/ZipVerifier.kt
+++ b/lib/src/main/kotlin/org/jetbrains/zip/signer/verifier/ZipVerifier.kt
@@ -2,7 +2,7 @@ package org.jetbrains.zip.signer.verifier
 
 
 import org.jetbrains.zip.signer.datasource.DataSource
-import org.jetbrains.zip.signer.datasource.FileChannelDataSource
+import org.jetbrains.zip.signer.datasource.SeekableByteChannelDataSource
 import org.jetbrains.zip.signer.digest.DigestUtils
 import org.jetbrains.zip.signer.exceptions.ZipVerificationException
 import org.jetbrains.zip.signer.metadata.ContentDigestAlgorithm
@@ -56,7 +56,7 @@ object ZipVerifier {
     @JvmStatic
     @Throws(IOException::class)
     fun verify(path: Path): ZipVerificationResult {
-        return FileChannel.open(path, StandardOpenOption.READ).use { verify(FileChannelDataSource(it)) }
+        return FileChannel.open(path, StandardOpenOption.READ).use { verify(SeekableByteChannelDataSource(it)) }
     }
 
     fun verify(dataSource: DataSource): ZipVerificationResult {


### PR DESCRIPTION
…. Rename to SeekableByteChannelDataSource. Keep FileChannelDataSource for the sake of backward compatibility